### PR TITLE
Add navigation bar to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,75 @@
     }
     /* Optional: hide scrollbar if any */
     ::-webkit-scrollbar { width: 0; height: 0; }
+
+    /* NAV: NoDrama Records */
+    .header {
+      background: #000;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+
+    .header__links {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 0 20px;
+    }
+
+    .header__links-list {
+      display: flex;
+      gap: 30px;
+      list-style: none;
+      margin: 0;
+      padding: 12px 0;
+    }
+
+    .header__links-list a {
+      color: #fff;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-weight: 600;
+      font-size: 14px;
+      padding: 10px 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .header__links-list a:hover {
+      opacity: 0.8;
+    }
+
+    @media (max-width: 768px) {
+      .header__links-list {
+        flex-wrap: wrap;
+        gap: 15px;
+        justify-content: center;
+        padding: 10px 0;
+      }
+
+      .header__links-list a {
+        font-size: 12px;
+        padding: 8px 0;
+      }
+    }
   </style>
 </head>
 <body>
+  <!-- NAV: NoDrama Records -->
+  <header class="header">
+    <nav class="header__links header__links-primary" data-navigation>
+      <ul class="header__links-list fs-navigation-base">
+        <li><a href="events.html" data-link><span class="link-hover">EVENTS</span></a></li>
+        <li><a href="artists.html" data-link><span class="link-hover">ARTISTS</span></a></li>
+        <li><a href="releases.html" data-link><span class="link-hover">RELEASES</span></a></li>
+        <li><a href="merch.html" data-link><span class="link-hover">MERCH</span></a></li>
+        <li><a href="studio.html" data-link><span class="link-hover">STUDIO</span></a></li>
+        <li><a href="podcasts-streams.html" data-link><span class="link-hover">PODCASTS/STREAMS</span></a></li>
+        <li><a href="contact.html" data-link><span class="link-hover">CONTACT</span></a></li>
+      </ul>
+    </nav>
+  </header>
+
   <canvas id="dark-veil-canvas"></canvas>
 
   <script>


### PR DESCRIPTION
## Summary
- add top navigation bar with links to events, artists, releases, merch, studio, podcasts/streams, and contact
- style navigation for desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c87453dcc8329b6b48c4e3f869906